### PR TITLE
Replace scipy.ndimage with imageio

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Scale Control examples made with [Neural-Style](https://github.com/jcjohnson/neu
 
 ### Dependencies: 
 
-`sudo apt-get install python-skimage`
+`sudo pip install imageio`
 
 `sudo pip install numpy`
 

--- a/linear-color-transfer.py
+++ b/linear-color-transfer.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import argparse
-import scipy.ndimage as spi
+import imageio
 from skimage import io,transform,img_as_float
 from skimage.io import imread,imsave
 from PIL import Image
@@ -26,8 +26,8 @@ Image.MAX_IMAGE_PIXELS = 1000000000 # Support gigapixel images
 
 def main():   
 
-    target_img = spi.imread(args.target_image, mode="RGB").astype(float)/256
-    source_img = spi.imread(args.source_image, mode="RGB").astype(float)/256
+    target_img = imageio.imread(args.target_image, pilmode="RGB").astype(float)/256
+    source_img = imageio.imread(args.source_image, pilmode="RGB").astype(float)/256
 
     output_img = match_color(target_img, source_img, mode=args.mode, eps=args.eps)
     imsave(args.output_image, output_img)

--- a/lum-transfer.py
+++ b/lum-transfer.py
@@ -6,7 +6,7 @@
 import skimage 
 import numpy as np
 import argparse
-import scipy.ndimage as spi
+import imageio
 from skimage import io,transform,img_as_float
 from skimage.io import imread,imsave
 from PIL import Image
@@ -92,9 +92,9 @@ if cp_mode == 'lum':
 	    style_img = args.style_image
 	    content_img = args.content_image
             org_content = args.org_content
-	    org_content = spi.imread(org_content, mode="RGB").astype(float)/256
-            style_img = spi.imread(style_img, mode="RGB").astype(float)/256
-	    content_img = spi.imread(content_img, mode="RGB").astype(float)/256
+	    org_content = imageio.imread(org_content, pilmode="RGB").astype(float)/256
+            style_img = imageio.imread(style_img, pilmode="RGB").astype(float)/256
+	    content_img = imageio.imread(content_img, pilmode="RGB").astype(float)/256
 	    
             org_content = content_img.copy()
             style_img = lum_transform(style_img)
@@ -113,8 +113,8 @@ if cp_mode == 'lum':
 elif cp_mode =='match':
 	    style_img = args.style_image
 	    content_img = args.content_image
-	    style_img = spi.imread(style_img, mode="RGB").astype(float)/256
-	    content_img = spi.imread(content_img, mode="RGB").astype(float)/256
+	    style_img = imageio.imread(style_img, pilmode="RGB").astype(float)/256
+	    content_img = imageio.imread(content_img, pilmode="RGB").astype(float)/256
 
             style_img = match_color(style_img, content_img, mode='pca')
 
@@ -122,8 +122,8 @@ elif cp_mode =='match':
 elif cp_mode == 'match_style':
 	    style_img = args.style_image
 	    content_img = args.content_image
- 	    style_img = spi.imread(style_img, mode="RGB").astype(float)/256
-	    content_img = spi.imread(content_img, mode="RGB").astype(float)/256
+ 	    style_img = imageio.imread(style_img, pilmode="RGB").astype(float)/256
+	    content_img = imageio.imread(content_img, pilmode="RGB").astype(float)/256
 
             content_img = match_color(content_img, style_img, mode='pca')
 		
@@ -131,8 +131,8 @@ elif cp_mode == 'match_style':
 elif cp_mode == 'lum2':
             output = args.output_lum2
             org_content = args.org_content
-	    org_content = spi.imread(org_content, mode="RGB").astype(float)/256
-	    output = spi.imread(output, mode="RGB").astype(float)/256
+	    org_content = imageio.imread(org_content, pilmode="RGB").astype(float)/256
+	    output = imageio.imread(output, pilmode="RGB").astype(float)/256
 	
 	    org_content = skimage.transform.resize(org_content, output.shape)
 		


### PR DESCRIPTION
- `scipy.ndimage`'s `imread` has been deprecated, and replaced by `imageio`'s `imread`. Source: https://imageio.readthedocs.io/en/stable/scipy.html